### PR TITLE
Add consensus rewards API project

### DIFF
--- a/projects/project-ideas.md
+++ b/projects/project-ideas.md
@@ -14,6 +14,7 @@ Here is a list of projects proposed by mentors. If you would like to know more a
 - [Debug tools](#debug-tools)
 - [Improving hive for End-to-End Testing](#improving-hive-for-end-to-end-testing)
 - [By Potuz](#by-potuz)
+- [Consensus client reward APIs](#consensus-client-reward-apis)
 
 ### Previous cohorts
 
@@ -95,3 +96,17 @@ working with different members of the prysmaticlabs team.
 - Beacon API compliant validator client: Long term project of rewriting the validator client code to be compatible with the Beacon API instead of prysmaticlabs' internal API. 
 - Type consistency between forkchoice and the beacon-chain package. 
 
+### Consensus client reward APIs
+
+Presently there are no cross-client APIs for calculating the rewards paid to validators for publishing attestations, block proposals and other messages.
+
+This creates an unnecessary barrier to entry for the development of tools like block explorers and GUIs, requiring application devs to reverse-engineer consensus reward code.
+
+To improve the situation it would be great to have a simple HTTP API available in every consensus client that outputs reward data. This project could involve:
+
+- Design and standardisation of the HTTP API spec in [beacon-APIs](https://github.com/ethereum/beacon-APIs).
+- Implementation of production-ready (or proof-of-concept) APIs in one or more consensus clients. Different fellows could implement the APIs in different clients.
+- Design and implementation of a local indexing module to track rewards for nominated validators without a block explorer. This could either be a standalone tool leaning
+  on the APIs, or integrated into a consensus client. For prior work along these lines see Nimbus' [attestation performance tracking](https://nimbus.guide/attestation-performance.html).
+
+Mentor: @michaelsproul (SigP/Lighthouse)


### PR DESCRIPTION
Project proposal for standardised HTTP APIs for consensus client rewards.

I have already discussed this project with @kevinbogner, who is interested in taking it on. 

There is also likely room for other fellows to take on implementations in other clients (Prysm, Teku, Nimbus, Lodestar).